### PR TITLE
Add instead of set the X-Forwarded-Port header

### DIFF
--- a/resources/content/config-content/haproxy/content/etc/haproxy/haproxy.cfg.ftl
+++ b/resources/content/config-content/haproxy/content/etc/haproxy/haproxy.cfg.ftl
@@ -92,7 +92,7 @@ backend ${listener.uuid}_${backend.uuid}_backend
          <#if listener.sourceProtocol == "https">
         http-request add-header X-Forwarded-Proto https if { ssl_fc }
         </#if>
-        http-request set-header X-Forwarded-Port %[dst_port]
+        http-request add-header X-Forwarded-Port %[dst_port]
         
 </#list>
 </#list>


### PR DESCRIPTION
The haproxy sets the X-Forwarded-Port header instead of adding it. This breaks http servers that rely on this header to create URLs if other loadbalancers or proxies are put in front of rancher.

Our setup is:
- Https terminated on load balancer, which sets the X-Forwarded-Port port to 443, forwards to rancher
- rancher haproxy listening on port 80, setting X-Forwarded-Port to 80
- The http server creates wrong URLs in the form https://example.com:80 because it honors the X-Forwarded-* headers to create the URLs.